### PR TITLE
Fix GitHub Release CI

### DIFF
--- a/.github/workflows/release_gh.yml
+++ b/.github/workflows/release_gh.yml
@@ -16,3 +16,4 @@ jobs:
       uses: adafruit/workflows-circuitpython-libs/release-gh@main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        upload-url: ${{ github.event.release.upload_url }}


### PR DESCRIPTION
Noticed the new library and when checking it out noticed the GitHub release had failed - the cookiecutter was missing a field!  Pr to fix it here, and I'll submit a PR to the cookiecutter to fix it there.